### PR TITLE
Speedup - zshell init

### DIFF
--- a/.tmux.conf
+++ b/.tmux.conf
@@ -108,10 +108,16 @@ set-option -g status-right-length 90
 
 # Contents left
 #set-option -g status-left '#H:[#P]'
-set-option -g status-left 'tmux:[#P]'
+set-option -g status-left \
+"#[fg=cyan]#(${HOME}/.dotfiles/bin/tmux/git-echo-username-and-email)"\
+"#[fg=yellow] - tmux:[#P]"
 
 # Contents right
-set-option -g status-right '#[fg=white]#(/usr/local/bin/wifi)#[default] #(/usr/local/bin/battery --tmux) [%Y-%m-%d(%a) %H:%M]'
+set-option -g status-right \
+"#[fg=white]#(/usr/local/bin/wifi)"\
+"#[default]#(/usr/local/bin/battery --tmux)"\
+"#[fg=green]#(${HOME}/.dotfiles/bin/tmux/git-echo-branch-tmux-current-pane)"\
+"#[fg=yellow][%Y-%m-%d(%a) %H:%M]"
 
 # Reload statusbar
 set-option -g status-interval 1

--- a/.zsh.d/.zshrc
+++ b/.zsh.d/.zshrc
@@ -23,13 +23,13 @@ if [[ -f $ZPLUG_HOME/init.zsh ]]; then
   source $ZPLUG_HOME/init.zsh
 
   # install check
-  if ! zplug check --verbose; then
-    printf "Install? [y/N]: "
-    if read -q; then
-      echo; zplug install
-    fi
-      echo
-  fi
+  #if ! zplug check --verbose; then
+  #  printf "Install? [y/N]: "
+  #  if read -q; then
+  #    echo; zplug install
+  #  fi
+  #    echo
+  #fi
   zplug load
 fi
 

--- a/.zshenv
+++ b/.zshenv
@@ -13,7 +13,7 @@ path=( \
 autoload -Uz run-help
 autoload -Uz add-zsh-hook
 autoload -Uz colors && colors
-autoload -Uz compinit && compinit -u
+# autoload -Uz compinit && compinit -u -> comment out for speed-up
 autoload -Uz is-at-least
 autoload -Uz promptinit
 promptinit


### PR DESCRIPTION
- eb14194 comment out zplug install-check and comipinit
  - autoload is unnecessary if load in zplug after
  - do manually check zplug  yourself


- do nothing
```shell
❯ zshtime10
zsh -i -c exit  0.35s user 0.33s system 99% cpu 0.684 total
zsh -i -c exit  0.34s user 0.32s system 99% cpu 0.659 total
zsh -i -c exit  0.34s user 0.31s system 99% cpu 0.654 total
zsh -i -c exit  0.34s user 0.32s system 99% cpu 0.671 total
zsh -i -c exit  0.34s user 0.32s system 99% cpu 0.654 total
zsh -i -c exit  0.34s user 0.32s system 99% cpu 0.657 total
zsh -i -c exit  0.35s user 0.33s system 99% cpu 0.675 total
zsh -i -c exit  0.34s user 0.32s system 99% cpu 0.661 total
zsh -i -c exit  0.34s user 0.31s system 99% cpu 0.655 total
zsh -i -c exit  0.34s user 0.33s system 99% cpu 0.668 total
```
